### PR TITLE
Fix bug on back button where animation isn't found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,13 +63,15 @@ export default class JsPlugin extends Plugin {
 		const animation = this.options[index];
 
 		return new Promise((resolve) => {
-			animation[type](resolve, {
-				paramsFrom: animation.regFrom.exec(currentTransitionRoutes.from),
-				paramsTo: animation.regTo.exec(currentTransitionRoutes.to),
-				transition: currentTransitionRoutes,
-				from: animation.from,
-				to: animation.to
-			});
+			if( animation ) {
+				animation[type](resolve, {
+					paramsFrom: animation.regFrom.exec(currentTransitionRoutes.from),
+					paramsTo: animation.regTo.exec(currentTransitionRoutes.to),
+					transition: currentTransitionRoutes,
+					from: animation.from,
+					to: animation.to
+				});
+			}
 		});
 	};
 


### PR DESCRIPTION
Clicking the back button on Chrome gives the following error: 
<img width="985" alt="Screenshot 2019-12-09 at 20 40 41" src="https://user-images.githubusercontent.com/34285492/70467366-5844ba00-1ac5-11ea-84ef-c2b11380209d.png">

For some reason, when going back the animation isn't found, so the modified code is just to check whether the animation exists before executing the code